### PR TITLE
Updated the junit-platform-launcher to the latest one (1.12.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.10.1</version>
+            <version>1.12.2</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
It fixes the issue when adding libraries with updated versions and the offline goal doesn't process correctly:

Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.2.2:test (default-test) on project java-unit-tests-base: The following artifacts could not be resolved: org.junit.platform:junit-platform-launcher:jar:1.9.3 (absent): Cannot access central (https://repo.maven.apache.org/maven2) in offline mode and the artifact org.junit.platform:junit-platform-launcher:jar:1.9.3 has not been downloaded from it before. -> [Help 1]